### PR TITLE
💄 Improve Checklist usability on smaller screens

### DIFF
--- a/client/src/components/TripChecklist.vue
+++ b/client/src/components/TripChecklist.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="relative overflow-x-auto">
-    <SecondaryButton @click="editMode = !editMode" class="m-2">Rediger</SecondaryButton>
+    <SecondaryButton @click="editMode = !editMode" class="m-2">
+      {{ editMode ? 'Lagre' : 'Rediger' }}
+    </SecondaryButton>
 
     <p v-if="!items">
       <ListSkeleton />
@@ -11,8 +13,9 @@
         <tr>
           <th v-if="editMode"></th>
           <th class="px-2 py-2 w-full">Produkt</th>
+          <th class="px-1 md:px-6 py-2 max-md:hidden">Forsyningsmål</th>
           <th class="px-1 md:px-6 py-2 whitespace-nowrap">Antall</th>
-          <th class="px-2 md:px-6 py-2 whitespace-nowrap">Pakket</th>
+          <th v-if="!editMode" class="px-1 md:px-6 py-2 whitespace-nowrap">Pakket</th>
           <th v-if="editMode">Slett</th>
         </tr>
       </thead>
@@ -31,12 +34,11 @@
         <tr
           v-for="(item, pos) in items"
           :key="item.id"
-          class="border-b checklist-item"
+          class="checklist-item"
           :class="{
-            'cursor-move border-b-2 border-b-black':
-              dragHoverPosition === pos && dragStartPosition < pos,
-            'cursor-move border-t-2 border-t-black':
-              dragHoverPosition === pos && dragStartPosition > pos
+            'border-b-4 border-b-gray-600': dragHoverPosition === pos && dragStartPosition < pos,
+            'border-t-4 border-t-gray-600': dragHoverPosition === pos && dragStartPosition > pos,
+            'border-b border-b-gray-300': dragHoverPosition !== pos
           }"
           @dragstart="(e) => dragstart_handler(e, pos)"
           @drop="(e) => dropHandler(e, pos)"
@@ -46,8 +48,8 @@
           <td v-if="editMode" draggable="true" class="cursor-pointer pr-0">
             <DraggableItemIcon />
           </td>
-          <td class="w-full px-2 py-2 text-gray-900 md:flex">
-            <div class="flex-1">
+          <td class="w-full px-2 py-2 text-gray-900">
+            <div>
               <input
                 class="w-full py-0 md:py-1 rounded-sm outline-none"
                 :class="{
@@ -61,14 +63,42 @@
                 @blur="(event) => editItemName(item, event.target.value)"
               />
             </div>
-            <div class="flex-none px-0 md:px-4 py-0 pb-1" v-if="item.supply_target && !editMode">
-              <label class="text-xs md:text-sm"
+
+            <div class="md:hidden">
+              <div class="px-0 py-0 pb-1" v-if="item.supply_target && !editMode">
+                <label class="text-xs"
+                  ><span class="md:hidden">Forsyningsmål:</span
+                  >{{ item.supply_target?.name }}</label
+                >
+              </div>
+              <div class="px-0 md:px-4 py-0 pb-1" v-if="editMode">
+                <select
+                  class="text-xs text-gray-500 bg-transparent border-0 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200"
+                  :value="item.supply_target_id"
+                  @input="(event) => updateItem(item, 'supply_target_id', event.target.value)"
+                >
+                  <option value="" selected>---</option>
+                  <option
+                    v-for="supplyTarget in supplyTargets"
+                    :key="supplyTarget.id"
+                    :value="supplyTarget.id"
+                    @input="editItemSupplyTarget(item, supplyTarget.id)"
+                  >
+                    {{ supplyTarget.name }}
+                  </option>
+                </select>
+              </div>
+            </div>
+          </td>
+          <td class="max-md:hidden px-1 md:px-6 py-2 whitespace-nowrap">
+            <div class="px-0 py-0" v-if="item.supply_target && !editMode">
+              <label class="text-sm"
                 ><span class="md:hidden">Forsyningsmål:</span>{{ item.supply_target?.name }}</label
               >
             </div>
-            <div class="flex-none px-0 md:px-4 py-0 pb-1" v-if="editMode">
+            <div class="px-0 py-0" v-if="editMode">
               <select
-                class="text-xs md:text-sm text-gray-500 bg-transparent border-0 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200"
+                class="text-sm text-gray-500 bg-transparent border-0 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200"
                 :value="item.supply_target_id"
                 @input="(event) => updateItem(item, 'supply_target_id', event.target.value)"
               >
@@ -91,7 +121,7 @@
               :editable="editMode"
             />
           </td>
-          <td class="px-1 md:px-6 py-2 whitespace-nowrap text-right">
+          <td v-if="!editMode" class="px-1 md:px-6 py-2 whitespace-nowrap">
             <CheckBox
               v-model="item.packed"
               @input="updateItem(item, 'packed', !item.packed)"
@@ -316,8 +346,8 @@ onMounted(async () => {
   transition:
     all 0.5s ease,
     background-color 0s,
-    border-bottom 0s,
-    border-top 0s;
+    border-bottom 0.2s,
+    border-top 0.2s;
 }
 
 .checklist-enter,

--- a/client/src/components/TripChecklist.vue
+++ b/client/src/components/TripChecklist.vue
@@ -136,7 +136,7 @@
       </TransitionGroup>
     </table>
 
-    <div class="w-full px-6 py-4 font-semibold text-gray-400" ref="addNewRef">
+    <div class="w-full px-6 py-4 font-semibold" ref="addNewRef">
       <div class="relative">
         <TextInput
           class="!p-4 mb-3"

--- a/client/src/components/TripChecklist.vue
+++ b/client/src/components/TripChecklist.vue
@@ -1,21 +1,24 @@
 <template>
-  <div class="relative overflow-x-auto shadow-md sm:rounded-lg">
+  <div class="relative overflow-x-auto">
+    <SecondaryButton @click="editMode = !editMode" class="m-2">Rediger</SecondaryButton>
+
     <p v-if="!items">
       <ListSkeleton />
     </p>
-    <table v-else class="table-fixed text-sm text-left text-gray-500 rounded-md">
-      <thead class="text-lg text-gray-700 bg-gray-200">
+
+    <table v-else class="table-fixed text-left text-gray-500 rounded-md">
+      <thead class="text-xs uppercase text-gray-700 bg-gray-50">
         <tr>
-          <th class="px-2 py-3 w-full" colspan="2">Product</th>
-          <th class="px-1 md:px-6 py-3 whitespace-nowrap">SupplyTarget</th>
-          <th class="px-1 md:px-6 py-3 whitespace-nowrap">Qty</th>
-          <th class="px-2 md:px-6 py-3 whitespace-nowrap">Packed</th>
-          <th class="px-1 md:px-6 py-3 whitespace-nowrap">Action</th>
+          <th v-if="editMode"></th>
+          <th class="px-2 py-2 w-full">Produkt</th>
+          <th class="px-1 md:px-6 py-2 whitespace-nowrap">Antall</th>
+          <th class="px-2 md:px-6 py-2 whitespace-nowrap">Pakket</th>
+          <th v-if="editMode">Slett</th>
         </tr>
       </thead>
       <TransitionGroup name="checklist" tag="tbody">
         <tr v-if="items.length === 0">
-          <td colspan="5" class="text-left w-full px-5 py-3">
+          <td colspan="5" class="text-left w-full px-5 py-2">
             <p class="text-md">
               Du har ingenting i pakkelisten din enda! Vil du kopiere listen din fra sist?
             </p>
@@ -30,94 +33,80 @@
           :key="item.id"
           class="border-b checklist-item"
           :class="{
-            'cursor-move bg-gray-200': dragHoverPosition === pos,
-            'bg-gray-100': dragHoverPosition !== pos
+            'cursor-move border-b-2 border-b-black':
+              dragHoverPosition === pos && dragStartPosition < pos,
+            'cursor-move border-t-2 border-t-black':
+              dragHoverPosition === pos && dragStartPosition > pos
           }"
           @dragstart="(e) => dragstart_handler(e, pos)"
           @drop="(e) => dropHandler(e, pos)"
           @dragenter.prevent="dragHoverPosition = pos"
           @dragover.prevent
         >
-          <td draggable="true" class="cursor-pointer pr-0">
+          <td v-if="editMode" draggable="true" class="cursor-pointer pr-0">
             <DraggableItemIcon />
           </td>
-          <td class="w-full px-0 py-1 text-lg text-gray-900">
-            <input
-              class="w-full block px-4 py-2 rounded-md outline-none"
-              :class="{
-                'bg-transparent hover:bg-white cursor-pointer': !item._status?.editing,
-                'bg-white': item._status?.editing
-              }"
-              :value="item.name"
-              @click="item._status.editing = true"
-              @focus="item._status.editing = true"
-              @keydown.enter="(event) => editItemName(item, event.target.value)"
-              @blur="(event) => editItemName(item, event.target.value)"
-            />
-          </td>
-          <td class="px-1 md:px-6 py-3 whitespace-nowrap">
-            <select
-              class="block w-full px-4 py-2 text-sm border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500"
-              :value="item.supply_target_id"
-              @input="(event) => updateItem(item, 'supply_target_id', event.target.value)"
-            >
-              <option value="" selected>---</option>
-              <option
-                v-for="supplyTarget in supplyTargets"
-                :key="supplyTarget.id"
-                :value="supplyTarget.id"
-                @input="editItemSupplyTarget(item, supplyTarget.id)"
+          <td class="w-full px-2 py-2 text-gray-900 md:flex">
+            <div class="flex-1">
+              <input
+                class="w-full py-0 md:py-1 rounded-sm outline-none"
+                :class="{
+                  'bg-transparent hover:bg-white cursor-pointer': !item._status?.editing,
+                  'bg-gray-50 outline-1 outline-gray-400': item._status?.editing
+                }"
+                :value="item.name"
+                @click="item._status.editing = true"
+                @focus="item._status.editing = true"
+                @keydown.enter="(event) => editItemName(item, event.target.value)"
+                @blur="(event) => editItemName(item, event.target.value)"
+              />
+            </div>
+            <div class="flex-none px-0 md:px-4 py-0 pb-1" v-if="item.supply_target && !editMode">
+              <label class="text-xs md:text-sm"
+                ><span class="md:hidden">Forsyningsmål:</span>{{ item.supply_target?.name }}</label
               >
-                {{ supplyTarget.name }}
-              </option>
-            </select>
-          </td>
-          <td class="px-1 md:px-6 py-3 whitespace-nowrap">
-            <div class="flex items-center">
-              <SecondaryButton
-                class="me-3 !p-1 !rounded-full"
-                @click="updateItem(item, 'quantity', --item.quantity)"
+            </div>
+            <div class="flex-none px-0 md:px-4 py-0 pb-1" v-if="editMode">
+              <select
+                class="text-xs md:text-sm text-gray-500 bg-transparent border-0 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200"
+                :value="item.supply_target_id"
+                @input="(event) => updateItem(item, 'supply_target_id', event.target.value)"
               >
-                <span class="sr-only">Quantity button</span>
-                <MinusIcon class="text-gray-500 h-3 w-3" />
-              </SecondaryButton>
-
-              <div>
-                <input
-                  type="number"
-                  id="first_product"
-                  class="bg-gray-50 w-14 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block px-2.5 py-1"
-                  placeholder="0"
-                  :value="item.quantity"
-                  @input="(event) => updateItem(item, 'quantity', event.target.value)"
-                  required
-                />
-              </div>
-              <SecondaryButton
-                class="ms-3 !p-1 !rounded-full"
-                @click="updateItem(item, 'quantity', ++item.quantity)"
-              >
-                <span class="sr-only">Quantity button</span>
-                <PlusIcon class="text-gray-500 h-3 w-3" />
-              </SecondaryButton>
+                <option value="" selected>---</option>
+                <option
+                  v-for="supplyTarget in supplyTargets"
+                  :key="supplyTarget.id"
+                  :value="supplyTarget.id"
+                  @input="editItemSupplyTarget(item, supplyTarget.id)"
+                >
+                  {{ supplyTarget.name }}
+                </option>
+              </select>
             </div>
           </td>
-          <td class="px-1 md:px-6 py-3 whitespace-nowrap">
+          <td class="px-1 md:px-6 py-2 whitespace-nowrap">
+            <CounterInput
+              :value="item.quantity"
+              @update:value="($event) => updateItem(item, 'quantity', $event)"
+              :editable="editMode"
+            />
+          </td>
+          <td class="px-1 md:px-6 py-2 whitespace-nowrap text-right">
             <CheckBox
               v-model="item.packed"
               @input="updateItem(item, 'packed', !item.packed)"
             ></CheckBox>
           </td>
-          <td class="px-1 md:px-6 py-3 whitespace-nowrap">
-            <button @click="removeItem(item)" class="font-medium text-red-600 hover:underline">
-              Fjern
+          <td v-if="editMode" class="px-1 md:px-6 py-2 whitespace-nowrap text-right">
+            <button @click="removeItem(item)" class="hover:underline">
+              <CloseIcon class="bg-red w-10 h-10"></CloseIcon>
             </button>
           </td>
         </tr>
       </TransitionGroup>
     </table>
 
-    <div class="w-full px-6 py-4 font-semibold bg-gray-50 text-gray-400" ref="addNewRef">
+    <div class="w-full px-6 py-4 font-semibold text-gray-400" ref="addNewRef">
       <div class="relative">
         <TextInput
           class="!p-4 mb-3"
@@ -142,7 +131,6 @@
 <script setup>
 import ListSkeleton from '@/components/ListSkeleton.vue'
 import DraggableItemIcon from '@/components/icons/DraggableItemIcon.vue'
-import MinusIcon from '@/components/icons/MinusIcon.vue'
 import PlusIcon from '@/components/icons/PlusIcon.vue'
 import { scrollIntoView } from '@/components/utils'
 import { onMounted, ref } from 'vue'
@@ -151,6 +139,8 @@ import PrimaryButton from '@/components/ui/PrimaryButton.vue'
 import SecondaryButton from './ui/SecondaryButton.vue'
 import CheckBox from './ui/CheckBox.vue'
 import TextInput from './ui/TextInput.vue'
+import CloseIcon from './icons/CloseIcon.vue'
+import CounterInput from './ui/CounterInput.vue'
 
 const items = ref(null)
 const supplyTargets = ref(null)
@@ -158,7 +148,10 @@ const newItemName = ref('')
 const addNewRef = ref(null)
 const errorMsg = ref(null)
 const dragHoverPosition = ref(null)
+const dragStartPosition = ref(null)
 const remainingSuggestions = ref(null)
+
+const editMode = ref(false)
 
 const params = useRoute().params
 
@@ -172,6 +165,7 @@ Array.prototype.move = function (from, to) {
 }
 
 function dragstart_handler(event, startPos) {
+  dragStartPosition.value = startPos
   event.dataTransfer.setData('startPos', startPos)
   const parentRow = event.target.parentElement
   event.dataTransfer.setDragImage(parentRow, parentRow.width, parentRow.height)
@@ -321,7 +315,9 @@ onMounted(async () => {
 .checklist-item {
   transition:
     all 0.5s ease,
-    background-color 0s;
+    background-color 0s,
+    border-bottom 0s,
+    border-top 0s;
 }
 
 .checklist-enter,

--- a/client/src/components/TripChecklist.vue
+++ b/client/src/components/TripChecklist.vue
@@ -67,13 +67,13 @@
             <div class="md:hidden">
               <div class="px-0 py-0 pb-1" v-if="item.supply_target && !editMode">
                 <label class="text-xs"
-                  ><span class="md:hidden">Forsyningsmål:</span
+                  ><span class="md:hidden">Forsyningsmål: </span
                   >{{ item.supply_target?.name }}</label
                 >
               </div>
-              <div class="px-0 md:px-4 py-0 pb-1" v-if="editMode">
+              <div class="px-0 py-0" v-if="editMode">
                 <select
-                  class="text-xs text-gray-500 bg-transparent border-0 appearance-none focus:outline-none focus:ring-0 focus:border-gray-200"
+                  class="text-xs text-blue-600 py-1.5 border-0 appearance-none focus:outline-none focus:ring-0 focus:border-1 focus:border-gray-200"
                   :value="item.supply_target_id"
                   @input="(event) => updateItem(item, 'supply_target_id', event.target.value)"
                 >
@@ -90,7 +90,7 @@
               </div>
             </div>
           </td>
-          <td class="max-md:hidden px-1 md:px-6 py-2 whitespace-nowrap">
+          <td class="max-md:hidden px-0 md:px-6 py-2 whitespace-nowrap">
             <div class="px-0 py-0" v-if="item.supply_target && !editMode">
               <label class="text-sm"
                 ><span class="md:hidden">Forsyningsmål:</span>{{ item.supply_target?.name }}</label

--- a/client/src/components/ui/CounterInput.vue
+++ b/client/src/components/ui/CounterInput.vue
@@ -1,0 +1,45 @@
+<template>
+  <div>
+    <label for="counter-input" class="block mb-1 text-sm font-medium text-gray-900 sr-only"
+      >Antall:</label
+    >
+    <div class="relative flex items-center">
+      <button
+        v-if="props.editable"
+        type="button"
+        class="flex-shrink-0 bg-gray-100 hover:bg-gray-200 inline-flex items-center justify-center border border-gray-300 rounded-md h-5 w-5 focus:ring-gray-100 focus:ring-2 focus:outline-none"
+        @click="model--"
+      >
+        <MinusIcon />
+      </button>
+      <input
+        v-model.number="model"
+        type="text"
+        class="flex-shrink-0 text-gray-900 border-0 bg-transparent text-sm font-normal focus:outline-none focus:ring-0 max-w-[2.5rem] text-center"
+        pattern="[0-9]{2}"
+        value="12"
+      />
+      <button
+        v-if="props.editable"
+        type="button"
+        class="flex-shrink-0 bg-gray-100 hover:bg-gray-200 inline-flex items-center justify-center border border-gray-300 rounded-md h-5 w-5 focus:ring-gray-100 focus:ring-2 focus:outline-none"
+        @click="model++"
+      >
+        <PlusIcon />
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import MinusIcon from '../icons/MinusIcon.vue'
+import PlusIcon from '../icons/PlusIcon.vue'
+
+const model = defineModel('value')
+const props = defineProps({
+  editable: {
+    type: Boolean,
+    default: true
+  }
+})
+</script>

--- a/client/src/components/ui/CounterInput.vue
+++ b/client/src/components/ui/CounterInput.vue
@@ -3,9 +3,8 @@
     <label for="counter-input" class="block mb-1 text-sm font-medium text-gray-900 sr-only"
       >Antall:</label
     >
-    <div class="relative flex items-center">
+    <div v-if="props.editable" class="relative flex items-center">
       <button
-        v-if="props.editable"
         type="button"
         class="flex-shrink-0 bg-gray-100 hover:bg-gray-200 inline-flex items-center justify-center border border-gray-300 rounded-md h-5 w-5 focus:ring-gray-100 focus:ring-2 focus:outline-none"
         @click="model--"
@@ -20,7 +19,6 @@
         value="12"
       />
       <button
-        v-if="props.editable"
         type="button"
         class="flex-shrink-0 bg-gray-100 hover:bg-gray-200 inline-flex items-center justify-center border border-gray-300 rounded-md h-5 w-5 focus:ring-gray-100 focus:ring-2 focus:outline-none"
         @click="model++"
@@ -28,6 +26,7 @@
         <PlusIcon />
       </button>
     </div>
+    <div v-else class="text-sm font-normal text-gray-900">{{ model }}</div>
   </div>
 </template>
 

--- a/client/src/views/TripView.vue
+++ b/client/src/views/TripView.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="container max-w-screen-lg mx-auto py-20">
-    <main class="bg-white p-10 rounded-lg shadow">
+  <div class="container max-w-screen-lg mx-auto py-0 md:py-20">
+    <main class="bg-white p-4 md:p-10 rounded-none md:rounded-lg shadow">
       <h2 class="text-5xl font-bold text-[#08384e] max-w-prose pb-4">{{ trip?.name }}</h2>
 
       <nav class="text-sm font-medium text-center text-gray-500 border-b border-gray-200 mb-4">


### PR DESCRIPTION
Related to issue https://github.com/esandoe/campster/issues/4.

Multiple changes done to improve how the checklist table is shown on smaller screens. Also added a "edit" mode, which lets us show a more clean table when not making changes.

Mobil vanlig visning:
<img width="416" alt="image" src="https://github.com/user-attachments/assets/da6958ae-6871-4f6c-bd5f-9655bcc078bb">

Mobil redigeringsvisning:
<img width="419" alt="image" src="https://github.com/user-attachments/assets/34f5d389-c2be-42ff-8415-7df0c0c53105">

Desktop vanlig visning:
<img width="1079" alt="image" src="https://github.com/user-attachments/assets/705abb48-367e-4edf-9492-682405f6f6bb">

Desktop redigeringsvisning:
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/44f9c21b-3c8f-4b98-9bf7-d170c5d23e37">


