### PR TITLE
✨ Add Dockerfile and docker-compose configuration for client application build

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,11 @@
+#  Dockerfile to build the client application using node 24
+
+FROM node:24-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY . .

--- a/client/docker-compose.yml
+++ b/client/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.9'
+services:
+  client-build:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./dist:/app/dist
+    command: ['npm', 'run', 'build']

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore",
-    "format": "prettier --write src/"
+    "format": "prettier --write src/",
+    "docker-build": "docker compose up --build"
   },
   "dependencies": {
     "@headlessui/vue": "1.7.23",


### PR DESCRIPTION
I wanted an easier way to build the client on my server, which apperantly had an older node versjon. I dont want the pain of updating node versions so i figured we could use docker instead!

Now we can go `npm run docker-build` which will spin up a container, build the client assets, and dump it back into the dist/ folder.