### PR TITLE
🐛 Remove dark mode classes from various components

### DIFF
--- a/client/src/components/ListSkeleton.vue
+++ b/client/src/components/ListSkeleton.vue
@@ -1,42 +1,42 @@
 <template>
   <div
     role="status"
-    class="p-4 space-y-4 border border-gray-200 divide-y divide-gray-200 rounded shadow animate-pulse dark:divide-gray-700 md:p-6 dark:border-gray-700"
+    class="p-4 space-y-4 border border-gray-200 divide-y divide-gray-200 rounded shadow animate-pulse md:p-6"
   >
     <div class="flex items-center justify-between">
       <div>
-        <div class="h-2.5 bg-gray-300 rounded-full dark:bg-gray-600 w-24 mb-2.5"></div>
-        <div class="w-32 h-2 bg-gray-200 rounded-full dark:bg-gray-700"></div>
+        <div class="h-2.5 bg-gray-300 rounded-full w-24 mb-2.5"></div>
+        <div class="w-32 h-2 bg-gray-200 rounded-full"></div>
       </div>
-      <div class="h-2.5 bg-gray-300 rounded-full dark:bg-gray-700 w-12"></div>
+      <div class="h-2.5 bg-gray-300 rounded-full w-12"></div>
     </div>
     <div class="flex items-center justify-between pt-4">
       <div>
-        <div class="h-2.5 bg-gray-300 rounded-full dark:bg-gray-600 w-24 mb-2.5"></div>
-        <div class="w-32 h-2 bg-gray-200 rounded-full dark:bg-gray-700"></div>
+        <div class="h-2.5 bg-gray-300 rounded-full w-24 mb-2.5"></div>
+        <div class="w-32 h-2 bg-gray-200 rounded-full"></div>
       </div>
-      <div class="h-2.5 bg-gray-300 rounded-full dark:bg-gray-700 w-12"></div>
+      <div class="h-2.5 bg-gray-300 rounded-full w-12"></div>
     </div>
     <div class="flex items-center justify-between pt-4">
       <div>
-        <div class="h-2.5 bg-gray-300 rounded-full dark:bg-gray-600 w-24 mb-2.5"></div>
-        <div class="w-32 h-2 bg-gray-200 rounded-full dark:bg-gray-700"></div>
+        <div class="h-2.5 bg-gray-300 rounded-full w-24 mb-2.5"></div>
+        <div class="w-32 h-2 bg-gray-200 rounded-full"></div>
       </div>
-      <div class="h-2.5 bg-gray-300 rounded-full dark:bg-gray-700 w-12"></div>
+      <div class="h-2.5 bg-gray-300 rounded-full w-12"></div>
     </div>
     <div class="flex items-center justify-between pt-4">
       <div>
-        <div class="h-2.5 bg-gray-300 rounded-full dark:bg-gray-600 w-24 mb-2.5"></div>
-        <div class="w-32 h-2 bg-gray-200 rounded-full dark:bg-gray-700"></div>
+        <div class="h-2.5 bg-gray-300 rounded-full w-24 mb-2.5"></div>
+        <div class="w-32 h-2 bg-gray-200 rounded-full"></div>
       </div>
-      <div class="h-2.5 bg-gray-300 rounded-full dark:bg-gray-700 w-12"></div>
+      <div class="h-2.5 bg-gray-300 rounded-full w-12"></div>
     </div>
     <div class="flex items-center justify-between pt-4">
       <div>
-        <div class="h-2.5 bg-gray-300 rounded-full dark:bg-gray-600 w-24 mb-2.5"></div>
-        <div class="w-32 h-2 bg-gray-200 rounded-full dark:bg-gray-700"></div>
+        <div class="h-2.5 bg-gray-300 rounded-full w-24 mb-2.5"></div>
+        <div class="w-32 h-2 bg-gray-200 rounded-full"></div>
       </div>
-      <div class="h-2.5 bg-gray-300 rounded-full dark:bg-gray-700 w-12"></div>
+      <div class="h-2.5 bg-gray-300 rounded-full w-12"></div>
     </div>
     <span class="sr-only">Loading...</span>
   </div>

--- a/client/src/components/TripCard.vue
+++ b/client/src/components/TripCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="p-6 bg-white border border-gray-200 rounded-lg shadow flex flex-col gap-2">
     <div class="flex items-center justify-between mb-2">
-      <h5 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-white">
+      <h5 class="text-2xl font-bold tracking-tight text-gray-900">
         {{ trip.name }}
       </h5>
       <span
@@ -20,13 +20,13 @@
     <a href="#" class="block">
       <div class="flex flex-row space-x-2 py-0">
         <UserGroupIcon />
-        <p class="mb-3 font-normal text-gray-400 dark:text-gray-400">
+        <p class="mb-3 font-normal text-gray-400">
           {{ pluralize(trip.participants.length, 'deltaker', 'deltakere') }}
         </p>
       </div>
       <div class="flex flex-row space-x-2 py-0">
         <MapPinAltIcon />
-        <p class="mb-3 font-normal text-gray-400 dark:text-gray-400">
+        <p class="mb-3 font-normal text-gray-400">
           {{ trip.location ?? 'N/A' }}
         </p>
       </div>

--- a/client/src/components/icons/AnonymousUserIcon.vue
+++ b/client/src/components/icons/AnonymousUserIcon.vue
@@ -1,6 +1,6 @@
 <template>
   <svg
-    class="w-10 h-10 my-3 text-gray-800 dark:text-white"
+    class="w-10 h-10 my-3 text-gray-800"
     aria-hidden="true"
     xmlns="http://www.w3.org/2000/svg"
     width="24"

--- a/client/src/components/icons/ArrowDownIcon.vue
+++ b/client/src/components/icons/ArrowDownIcon.vue
@@ -1,6 +1,6 @@
 <template>
   <svg
-    class="w-6 h-6 text-gray-800 dark:text-white"
+    class="w-6 h-6 text-gray-800"
     aria-hidden="true"
     xmlns="http://www.w3.org/2000/svg"
     width="24"

--- a/client/src/components/icons/ArrowLeftIcon.vue
+++ b/client/src/components/icons/ArrowLeftIcon.vue
@@ -1,6 +1,6 @@
 <template>
   <svg
-    class="w-6 h-6 text-gray-800 dark:text-white"
+    class="w-6 h-6 text-gray-800"
     aria-hidden="true"
     xmlns="http://www.w3.org/2000/svg"
     width="24"

--- a/client/src/components/icons/ArrowUpIcon.vue
+++ b/client/src/components/icons/ArrowUpIcon.vue
@@ -1,6 +1,6 @@
 <template>
   <svg
-    class="w-6 h-6 text-gray-800 dark:text-white"
+    class="w-6 h-6 text-gray-800"
     aria-hidden="true"
     xmlns="http://www.w3.org/2000/svg"
     width="24"

--- a/client/src/components/icons/MapPinAltIcon.vue
+++ b/client/src/components/icons/MapPinAltIcon.vue
@@ -1,6 +1,6 @@
 <template>
   <svg
-    class="w-6 h-6 text-gray-800 dark:text-white"
+    class="w-6 h-6 text-gray-800"
     aria-hidden="true"
     xmlns="http://www.w3.org/2000/svg"
     width="24"

--- a/client/src/components/icons/UserGroupIcon.vue
+++ b/client/src/components/icons/UserGroupIcon.vue
@@ -1,6 +1,6 @@
 <template>
   <svg
-    class="w-6 h-6 text-gray-800 dark:text-white"
+    class="w-6 h-6 text-gray-800"
     aria-hidden="true"
     xmlns="http://www.w3.org/2000/svg"
     width="24"

--- a/client/src/components/ui/TextInput.vue
+++ b/client/src/components/ui/TextInput.vue
@@ -3,7 +3,7 @@
     v-if="name"
     :id="labelId"
     for="email"
-    class="block mb-2 text-sm font-medium text-gray-900 dark:text-white"
+    class="block mb-2 text-sm font-medium text-gray-900"
     >{{ name }}</label
   >
   <input
@@ -13,15 +13,14 @@
     v-bind:aria-describedby="helperTextId"
     class="block w-full p-2.5 text-sm rounded-lg border text-gray-700 bg-gray-100 border-gray-300 focus:ring-blue-500 focus:border-blue-500 disabled:text-gray-500 disabled:bg-gray-200 disabled:cursor-not-allowed"
     :class="{
-      'bg-red-50 border-red-500 text-red-900 focus:ring-red-500 dark:bg-gray-700 focus:border-red-500':
-        !!error
+      'bg-red-50 border-red-500 text-red-900 focus:ring-red-500 focus:border-red-500': !!error
     }"
   />
-  <p v-if="description" :id="helperTextId" class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+  <p v-if="description" :id="helperTextId" class="mt-2 text-sm text-gray-500">
     {{ description }}
   </p>
 
-  <p v-if="!!error" class="mt-2 text-sm text-red-600 dark:text-red-500">
+  <p v-if="!!error" class="mt-2 text-sm text-red-600">
     <span class="font-medium">{{ error }}</span>
   </p>
 </template>

--- a/client/src/views/SettingsView.vue
+++ b/client/src/views/SettingsView.vue
@@ -16,9 +16,7 @@
 
       <div>
         <hr class="my-3" />
-        <label
-          for="avatar-selector"
-          class="block mb-2 text-sm font-medium text-gray-900 dark:text-white"
+        <label for="avatar-selector" class="block mb-2 text-sm font-medium text-gray-900"
           >Avatar</label
         >
         <div class="inline-block p-2 bg-gray-200">
@@ -29,9 +27,7 @@
           />
         </div>
 
-        <p id="avatar-textexplanation" class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-          Velg din avatar
-        </p>
+        <p id="avatar-textexplanation" class="mt-2 text-sm text-gray-500">Velg din avatar</p>
         <div class="flex bg-gray-100">
           <div class="flex flex-wrap">
             <div v-for="avatar in avatars" :key="avatar" class="inline-block m-3">
@@ -99,7 +95,7 @@
             <tr
               v-for="user in allUsers"
               :key="user.id"
-              class="odd:bg-white odd:dark:bg-gray-900 even:bg-gray-50 even:dark:bg-gray-800 border-b dark:border-gray-700"
+              class="odd:bg-white odd:even:bg-gray-50 even:border-b"
             >
               <th scope="row" class="px-2 py-2 w-full whitespace-nowrap">
                 {{ user.username }}
@@ -149,7 +145,7 @@
           />
         </div>
       </div>
-      <p v-if="addUserErrorMessage" class="mt-2 text-sm text-red-600 dark:text-red-500">
+      <p v-if="addUserErrorMessage" class="mt-2 text-sm text-red-600">
         {{ addUserErrorMessage }}
       </p>
       <PrimaryButton @click.prevent="createUser()" class="mt-4">Opprett bruker</PrimaryButton>

--- a/client/src/views/TripSupplyView.vue
+++ b/client/src/views/TripSupplyView.vue
@@ -6,28 +6,26 @@
         <li class="pb-3 sm:pb-4">
           <div class="flex items-center space-x-4 rtl:space-x-reverse">
             <div class="flex-1 min-w-0">
-              <p class="text-sm font-medium text-gray-900 truncate dark:text-white">
+              <p class="text-sm font-medium text-gray-900 truncate">
                 {{ supplyTarget.name }}
               </p>
-              <div class="text-sm text-gray-500 truncate dark:text-gray-400 divide-y divide-none">
+              <div class="text-sm text-gray-500 truncate divide-y divide-none">
                 <div v-for="item in supplyTarget.items" :key="item.id" class="px-2">
                   {{ item.name }}: {{ item.quantity }}
                 </div>
               </div>
             </div>
-            <div class="inline-flex items-center text-base text-gray-900 dark:text-white">
+            <div class="inline-flex items-center text-base text-gray-900">
               Mål: <span class="font-semibold mx-4"> {{ supplyTarget.target_quantity }}</span>
             </div>
 
-            <div class="inline-flex items-center text-base text-gray-900 dark:text-white">
+            <div class="inline-flex items-center text-base text-gray-900">
               Bidrag: <span class="font-semibold mx-4"> {{ supplyTarget.sum }}</span>
             </div>
-            <div
-              class="inline-flex space-x-3 w-1/4 items-center text-base text-gray-900 dark:text-white"
-            >
+            <div class="inline-flex space-x-3 w-1/4 items-center text-base text-gray-900">
               <ProgressBar :progress="supplyTarget.progress" />
             </div>
-            <div class="inline-flex items-center text-base text-gray-900 dark:text-white">
+            <div class="inline-flex items-center text-base text-gray-900">
               <button
                 @click="removeSupplyTarget(supplyTarget)"
                 class="font-medium text-red-600 hover:underline"
@@ -39,17 +37,18 @@
         </li>
       </div>
       <div ref="addNewRef" class="w-full px-6 py-4 font-semibold bg-gray-100 text-gray-400">
-        <label for="add-item" class="mb-2 text-sm font-medium text-gray-900 sr-only dark:text-white"
+        <label for="add-item" class="mb-2 text-sm font-medium text-gray-900 sr-only"
           >Legg til ny</label
         >
         <div class="flex space-x-2">
           <div class="inline-block w-2/3">
-          <TextInput
-            type="text"
-            id="add-item-name"
-            class="bg-white !py-2"
-            placeholder="Legg til ny"
-          /> </div>
+            <TextInput
+              type="text"
+              id="add-item-name"
+              class="bg-white !py-2"
+              placeholder="Legg til ny"
+            />
+          </div>
           <input
             type="number"
             min="1"
@@ -57,12 +56,7 @@
             class="px-3 py-2 w-1/6 border border-gray-300 rounded-lg shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm text-gray-900"
             placeholder="Mål"
           />
-          <PrimaryButton
-            @click="addSupplyTarget"
-            class="w-1/6"
-          >
-            Legg til
-          </PrimaryButton>
+          <PrimaryButton @click="addSupplyTarget" class="w-1/6"> Legg til </PrimaryButton>
         </div>
       </div>
     </ul>
@@ -71,8 +65,8 @@
 
 <script setup>
 import ProgressBar from '@/components/ProgressBar.vue'
-import PrimaryButton from '@/components/ui/PrimaryButton.vue';
-import TextInput from '@/components/ui/TextInput.vue';
+import PrimaryButton from '@/components/ui/PrimaryButton.vue'
+import TextInput from '@/components/ui/TextInput.vue'
 import { onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
 


### PR DESCRIPTION
There is a "bug" which causes some text to disappear when your browser is in dark mode. Untill we implement a proper dark mode, it is better to simply remove all dark: style classes to prevent wonky UI.