### PR TITLE
Prompt new users to set password on first login

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -157,6 +157,7 @@ def get_profile():
             "id": current_user.id,
             "username": current_user.username,
             "is_admin": current_user.is_admin,
+            "is_pending": current_user.is_pending,
             "avatar": current_user.avatar,
         }
     )

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -50,6 +50,7 @@ def change_password():
         return jsonify(Error="Det gamle passordet er feil."), 400
 
     user.set_password(new_password)
+    user.is_pending = False
     db.session.commit()
 
     return jsonify(success=True), 200

--- a/client/src/views/LoginView.vue
+++ b/client/src/views/LoginView.vue
@@ -93,8 +93,13 @@ async function login() {
 
   const result = await response.json()
   if (result.Success) {
-    updateUser()
-    router.go(-1)
+    await updateUser()
+    if (currentUser.value?.is_pending) {
+      router.push({ name: 'settings', query: { pendingPassword: 'true' } })
+    } else {
+      router.go(-1)
+    }
+    return
   }
 
   error.value = result.Error

--- a/client/src/views/SettingsView.vue
+++ b/client/src/views/SettingsView.vue
@@ -56,6 +56,17 @@
     <div v-if="currentUser != null" class="w-1/2 p-4 rounded-lg shadow-sm md:flex-row bg-gray-50">
       <h2>Bytt passord</h2>
       <hr class="my-3" />
+      <div
+        v-if="currentUser.is_pending"
+        class="p-4 mb-4 text-sm text-yellow-800 rounded-lg bg-yellow-50 border border-yellow-300"
+        role="alert"
+      >
+        <strong class="font-bold">Viktig!</strong>
+        <p class="mt-1">
+          Du må sette et nytt passord før du kan fortsette. Dette er et midlertidig passord som må
+          endres.
+        </p>
+      </div>
       <form id="change-password-form" @submit.prevent="changePassword">
         <div>
           <TextInput name="Gammelt passord" type="password" v-model="oldPassword" required />
@@ -225,8 +236,9 @@ async function changePassword() {
     })
   })
     .then((response) => response.json())
-    .then((data) => {
+    .then(async (data) => {
       if (data.success) {
+        await updateUser()
         alert('Du byttet passord, flott!')
         oldPassword.value = ''
         newPassword.value = ''


### PR DESCRIPTION
## Summary

Implements automatic password change prompt for new users on first login.

## Changes
- Backend: Added is_pending field to profile API response
- Backend: Set is_pending to False when user changes password
- Frontend: Redirect pending users to settings page after login
- Frontend: Display warning message for pending users in settings

Fixes #3

Generated with [Claude Code](https://claude.ai/code)