### PR TITLE
Fix participant tab not appearing after joining trip

### DIFF
--- a/client/src/views/TripHomeView.vue
+++ b/client/src/views/TripHomeView.vue
@@ -158,7 +158,7 @@
 import ArrowRightIcon from '@/components/icons/ArrowRightIcon.vue'
 import ParticipantList from '@/components/ParticipantList.vue'
 import { useAuth } from '@/composables/auth'
-import { computed, onMounted, ref } from 'vue'
+import { computed, inject, onMounted, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import ImageUploadIcon from '@/components/icons/ImageUploadIcon.vue'
 import CloseIcon from '@/components/icons/CloseIcon.vue'
@@ -170,7 +170,7 @@ const { currentUser } = useAuth()
 
 const tripId = useRoute().params.tripId
 
-const participants = ref(null)
+const participants = inject('tripParticipants', ref(null))
 const trip = ref(null)
 const attachments = ref([])
 const sortedAttachments = computed(() => {
@@ -293,10 +293,8 @@ const joinTrip = async () => {
 onMounted(async () => {
   const tripResponse = await fetch(`/api/trips/${tripId}`)
   trip.value = await tripResponse.json()
-  participants.value = trip.value.participants
   const attachmentsResponse = await fetch(`/api/trips/${tripId}/attachments/`)
   attachments.value = await attachmentsResponse.json()
-  console.log(attachments.value)
 })
 </script>
 

--- a/client/src/views/TripView.vue
+++ b/client/src/views/TripView.vue
@@ -76,7 +76,7 @@
 </template>
 
 <script setup>
-import { onMounted, ref } from 'vue'
+import { onMounted, provide, ref } from 'vue'
 import { useRoute } from 'vue-router'
 import TextInput from '@/components/ui/TextInput.vue'
 import PrimaryButton from '@/components/ui/PrimaryButton.vue'
@@ -113,6 +113,8 @@ async function saveName() {
   }
   editingName.value = false
 }
+
+provide('tripParticipants', participants)
 
 onMounted(async () => {
   const tripResponse = await fetch(`/api/trips/${tripId}`)


### PR DESCRIPTION
Closes #42

`TripView` and `TripHomeView` each had their own `participants` ref. After joining, only the child's ref updated, leaving the parent's tab list stale until reload.

Fix: `TripView` now `provide`s the `participants` ref; `TripHomeView` `inject`s it. Pushing the new participant after a successful join immediately renders the tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

I've verified the fix :)